### PR TITLE
ENH: Use inclusive language and updated segment editor API

### DIFF
--- a/AutoSave/AutoSave.py
+++ b/AutoSave/AutoSave.py
@@ -13,7 +13,7 @@ import time
 
 class AutoSave(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):
@@ -36,7 +36,7 @@ This file was originally developed by Kyle Sunderland (Perk Lab, Queen's Univers
 
 class AutoSaveWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   """Uses ScriptedLoadableModuleWidget base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):
@@ -127,7 +127,7 @@ class AutoSaveLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
   this class and make use of the functionality without
   requiring an instance of the Widget.
   Uses ScriptedLoadableModuleLogic base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   AUTO_SAVE_ENABLED_PARAMETER_NAME = "AutoSaveEnabled"
@@ -238,7 +238,7 @@ class AutoSaveTest(ScriptedLoadableModuleTest):
   """
   This is the test case for your scripted module.
   Uses ScriptedLoadableModuleTest base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def runTest(self):

--- a/CharacterizeTransformMatrix/CharacterizeTransformMatrix.py
+++ b/CharacterizeTransformMatrix/CharacterizeTransformMatrix.py
@@ -13,7 +13,7 @@ import numpy as np
 
 class CharacterizeTransformMatrix(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
-    https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self, parent):
@@ -55,7 +55,7 @@ class CharacterizeTransformMatrixWidget(
     ScriptedLoadableModuleWidget, VTKObservationMixin
 ):
     """Uses ScriptedLoadableModuleWidget base class, available at:
-    https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self, parent=None):
@@ -140,7 +140,7 @@ class CharacterizeTransformMatrixLogic(ScriptedLoadableModuleLogic):
     this class and make use of the functionality without
     requiring an instance of the Widget.
     Uses ScriptedLoadableModuleLogic base class, available at:
-    https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self):
@@ -384,7 +384,7 @@ class CharacterizeTransformMatrixTest(ScriptedLoadableModuleTest):
     """
     This is the test case for your scripted module.
     Uses ScriptedLoadableModuleTest base class, available at:
-    https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def setUp(self):

--- a/CombineModels/CombineModels.py
+++ b/CombineModels/CombineModels.py
@@ -11,7 +11,7 @@ from slicer.util import VTKObservationMixin
 
 class CombineModels(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):
@@ -41,7 +41,7 @@ The module uses https://github.com/zippy84/vtkbool for processing.
 
 class CombineModelsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   """Uses ScriptedLoadableModuleWidget base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent=None):
@@ -270,7 +270,7 @@ class CombineModelsLogic(ScriptedLoadableModuleLogic):
   this class and make use of the functionality without
   requiring an instance of the Widget.
   Uses ScriptedLoadableModuleLogic base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self):
@@ -359,7 +359,7 @@ class CombineModelsTest(ScriptedLoadableModuleTest):
   """
   This is the test case for your scripted module.
   Uses ScriptedLoadableModuleTest base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def setUp(self):

--- a/CurvedPlanarReformat/CurvedPlanarReformat.py
+++ b/CurvedPlanarReformat/CurvedPlanarReformat.py
@@ -12,7 +12,7 @@ import logging
 
 class CurvedPlanarReformat(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):
@@ -37,7 +37,7 @@ and Steve Pieper, Isomics, Inc. and was partially funded by NIH grant 3P41RR0132
 
 class CurvedPlanarReformatWidget(ScriptedLoadableModuleWidget):
   """Uses ScriptedLoadableModuleWidget base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def setup(self):
@@ -161,7 +161,7 @@ class CurvedPlanarReformatLogic(ScriptedLoadableModuleLogic):
   this class and make use of the functionality without
   requiring an instance of the Widget.
   Uses ScriptedLoadableModuleLogic base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self):
@@ -494,7 +494,7 @@ class CurvedPlanarReformatTest(ScriptedLoadableModuleTest):
   """
   This is the test case for your scripted module.
   Uses ScriptedLoadableModuleTest base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def setUp(self):

--- a/DocumentationTools/DocumentationTools.py
+++ b/DocumentationTools/DocumentationTools.py
@@ -12,7 +12,7 @@ from slicer.util import VTKObservationMixin
 
 class DocumentationTools(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):
@@ -36,7 +36,7 @@ and Steve Pieper, Isomics, Inc. and was partially funded by NIH grant 3P41RR0132
 
 class DocumentationToolsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   """Uses ScriptedLoadableModuleWidget base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent=None):
@@ -122,7 +122,7 @@ class DocumentationToolsLogic(ScriptedLoadableModuleLogic):
   this class and make use of the functionality without
   requiring an instance of the Widget.
   Uses ScriptedLoadableModuleLogic base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   @staticmethod
@@ -267,7 +267,7 @@ class DocumentationToolsTest(ScriptedLoadableModuleTest):
   """
   This is the test case for your scripted module.
   Uses ScriptedLoadableModuleTest base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def setUp(self):

--- a/ImportOsirixROI/ImportOsirixROI.py
+++ b/ImportOsirixROI/ImportOsirixROI.py
@@ -11,7 +11,7 @@ from slicer.util import VTKObservationMixin
 
 class ImportOsirixROI(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):
@@ -34,7 +34,7 @@ This file was originally developed by Andras Lasso, PerkLab.
 
 class ImportOsirixROIWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   """Uses ScriptedLoadableModuleWidget base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent=None):
@@ -210,7 +210,7 @@ class ImportOsirixROILogic(ScriptedLoadableModuleLogic):
   this class and make use of the functionality without
   requiring an instance of the Widget.
   Uses ScriptedLoadableModuleLogic base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
   def __init__(self):
     ScriptedLoadableModuleLogic.__init__(self)
@@ -391,7 +391,7 @@ class ImportOsirixROITest(ScriptedLoadableModuleTest):
   """
   This is the test case for your scripted module.
   Uses ScriptedLoadableModuleTest base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def setUp(self):

--- a/Lights/Lights.py
+++ b/Lights/Lights.py
@@ -11,7 +11,7 @@ import logging
 
 class Lights(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):
@@ -57,7 +57,7 @@ This file was originally developed by Andras Lasso.
 
 class LightsWidget(ScriptedLoadableModuleWidget):
   """Uses ScriptedLoadableModuleWidget base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def setup(self):

--- a/LineProfile/LineProfile.py
+++ b/LineProfile/LineProfile.py
@@ -10,7 +10,7 @@ import logging
 
 class LineProfile(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):
@@ -33,7 +33,7 @@ This file was originally developed by Andras Lasso (PerkLab)  and was partially 
 
 class LineProfileWidget(ScriptedLoadableModuleWidget):
   """Uses ScriptedLoadableModuleWidget base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def setup(self):
@@ -204,7 +204,7 @@ class LineProfileLogic(ScriptedLoadableModuleLogic):
   this class and make use of the functionality without
   requiring an instance of the Widget.
   Uses ScriptedLoadableModuleLogic base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self):
@@ -422,7 +422,7 @@ class LineProfileTest(ScriptedLoadableModuleTest):
   """
   This is the test case for your scripted module.
   Uses ScriptedLoadableModuleTest base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def setUp(self):

--- a/LoadRemoteFile/LoadRemoteFile.py
+++ b/LoadRemoteFile/LoadRemoteFile.py
@@ -24,7 +24,7 @@ from slicer.util import VTKObservationMixin
 
 class LoadRemoteFile(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):

--- a/RemoveCtTable/RemoveCtTable.py
+++ b/RemoveCtTable/RemoveCtTable.py
@@ -14,7 +14,7 @@ from slicer.util import VTKObservationMixin
 
 class RemoveCtTable(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):
@@ -36,7 +36,7 @@ See more information in <a href="https://github.com/PerkLab/SlicerSandbox#remove
 
 class RemoveCtTableWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   """Uses ScriptedLoadableModuleWidget base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent=None):
@@ -232,7 +232,7 @@ class RemoveCtTableLogic(ScriptedLoadableModuleLogic):
   this class and make use of the functionality without
   requiring an instance of the Widget.
   Uses ScriptedLoadableModuleLogic base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self):
@@ -290,7 +290,7 @@ class RemoveCtTableLogic(ScriptedLoadableModuleLogic):
     segmentEditorNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentEditorNode", "__temp_RemoveCtTableSegmentEditor")
     segmentEditorWidget.setMRMLSegmentEditorNode(segmentEditorNode)
     segmentEditorWidget.setSegmentationNode(segmentationNode)
-    segmentEditorWidget.setMasterVolumeNode(inputVolume)
+    segmentEditorWidget.setSourceVolumeNode(inputVolume)
 
     # Check that required extensions are installed
 
@@ -361,7 +361,7 @@ class RemoveCtTableTest(ScriptedLoadableModuleTest):
   """
   This is the test case for your scripted module.
   Uses ScriptedLoadableModuleTest base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def setUp(self):

--- a/SceneRecorder/SceneRecorder.py
+++ b/SceneRecorder/SceneRecorder.py
@@ -11,7 +11,7 @@ from slicer.util import VTKObservationMixin
 
 class SceneRecorder(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):
@@ -34,7 +34,7 @@ This file was originally developed by Andras Lasso (PerkLab).
 
 class SceneRecorderWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   """Uses ScriptedLoadableModuleWidget base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent=None):
@@ -140,7 +140,7 @@ class SceneRecorderLogic(ScriptedLoadableModuleLogic):
   this class and make use of the functionality without
   requiring an instance of the Widget.
   Uses ScriptedLoadableModuleLogic base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self):
@@ -316,7 +316,7 @@ class SceneRecorderTest(ScriptedLoadableModuleTest):
   """
   This is the test case for your scripted module.
   Uses ScriptedLoadableModuleTest base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def setUp(self):

--- a/SegmentCrossSectionArea/SegmentCrossSectionArea.py
+++ b/SegmentCrossSectionArea/SegmentCrossSectionArea.py
@@ -11,7 +11,7 @@ from slicer.util import VTKObservationMixin
 
 class SegmentCrossSectionArea(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):
@@ -33,7 +33,7 @@ This file was originally developed by Hollister Herhold and Andras Lasso.
 
 class SegmentCrossSectionAreaWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   """Uses ScriptedLoadableModuleWidget base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent=None):
@@ -239,7 +239,7 @@ class SegmentCrossSectionAreaLogic(ScriptedLoadableModuleLogic):
   this class and make use of the functionality without
   requiring an instance of the Widget.
   Uses ScriptedLoadableModuleLogic base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def setDefaultParameters(self, parameterNode):
@@ -438,7 +438,7 @@ class SegmentCrossSectionAreaTest(ScriptedLoadableModuleTest):
   """
   This is the test case for your scripted module.
   Uses ScriptedLoadableModuleTest base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def setUp(self):
@@ -466,16 +466,16 @@ class SegmentCrossSectionAreaTest(ScriptedLoadableModuleTest):
 
     self.delayDisplay("Starting the test")
 
-    # Load master volume
+    # Load source volume
     import SampleData
     sampleDataLogic = SampleData.SampleDataLogic()
-    masterVolumeNode = sampleDataLogic.downloadMRBrainTumor1()
+    sourceVolumeNode = sampleDataLogic.downloadMRBrainTumor1()
 
     # Create segmentation
     segmentationNode = slicer.vtkMRMLSegmentationNode()
     slicer.mrmlScene.AddNode(segmentationNode)
     segmentationNode.CreateDefaultDisplayNodes()  # only needed for display
-    segmentationNode.SetReferenceImageGeometryParameterFromVolumeNode(masterVolumeNode)
+    segmentationNode.SetReferenceImageGeometryParameterFromVolumeNode(sourceVolumeNode)
 
     # Create a sphere shaped segment
     radius = 20
@@ -492,7 +492,7 @@ class SegmentCrossSectionAreaTest(ScriptedLoadableModuleTest):
     plotChartNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLPlotChartNode", "Segment cross-section area plot")
 
     logic = SegmentCrossSectionAreaLogic()
-    logic.run(segmentationNode, masterVolumeNode, "slice", tableNode, plotChartNode)
+    logic.run(segmentationNode, sourceVolumeNode, "slice", tableNode, plotChartNode)
     logic.showChart(plotChartNode)
 
     self.assertEqual(tableNode.GetNumberOfColumns(), 3)

--- a/StitchVolumes/StitchVolumes.py
+++ b/StitchVolumes/StitchVolumes.py
@@ -13,7 +13,7 @@ from slicer.util import VTKObservationMixin
 
 class StitchVolumes(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
-    https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self, parent):
@@ -44,7 +44,7 @@ class StitchVolumes(ScriptedLoadableModule):
 
 class StitchVolumesWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """Uses ScriptedLoadableModuleWidget base class, available at:
-    https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self, parent=None):
@@ -305,7 +305,7 @@ class StitchVolumesLogic(ScriptedLoadableModuleLogic):
     this class and make use of the functionality without
     requiring an instance of the Widget.
     Uses ScriptedLoadableModuleLogic base class, available at:
-    https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def setDefaultParameters(self, parameterNode):
@@ -447,7 +447,7 @@ class StitchVolumesTest(ScriptedLoadableModuleTest):
     """
     This is the test case for your scripted module.
     Uses ScriptedLoadableModuleTest base class, available at:
-    https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def setUp(self):

--- a/StyleTester/StyleTester.py
+++ b/StyleTester/StyleTester.py
@@ -11,7 +11,7 @@ from slicer.util import VTKObservationMixin
 
 class StyleTester(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):
@@ -51,7 +51,7 @@ and Steve Pieper, Isomics, Inc. and was partially funded by NIH grant 3P41RR0132
 
 class StyleTesterWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   """Uses ScriptedLoadableModuleWidget base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent=None):
@@ -173,7 +173,7 @@ class StyleTesterLogic(ScriptedLoadableModuleLogic):
   this class and make use of the functionality without
   requiring an instance of the Widget.
   Uses ScriptedLoadableModuleLogic base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self):
@@ -192,7 +192,7 @@ class StyleTesterTest(ScriptedLoadableModuleTest):
   """
   This is the test case for your scripted module.
   Uses ScriptedLoadableModuleTest base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def setUp(self):

--- a/UserStatistics/UserStatistics.py
+++ b/UserStatistics/UserStatistics.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 
 class UserStatistics(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):
@@ -53,7 +53,7 @@ This file was originally developed by Kyle Sunderland (Perk Lab, Queen's Univers
 
 class UserStatisticsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   """Uses ScriptedLoadableModuleWidget base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):
@@ -201,7 +201,7 @@ class UserStatisticsLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
 
   COMPUTER_COLUMN_NAME = 'computer'
   USER_NAME_COLUMN_NAME = 'userName'
-  MASTER_VOLUME_NAME_COLUMN_NAME = 'masterVolumeName'
+  SOURCE_VOLUME_NAME_COLUMN_NAME = 'sourceVolumeName'
   START_TIME_COLUMN_NAME = 'startTime'
   SCENE_COLUMN_NAME = 'scene'
   SEGMENTATION_NAME_COLUMN_NAME = 'segmentationName'
@@ -217,7 +217,7 @@ class UserStatisticsLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
     OPERATION_COLUMN_NAME,
     DURATION_COLUMN_NAME,
     SEGMENT_NAME_COLUMN_NAME,
-    MASTER_VOLUME_NAME_COLUMN_NAME,
+    SOURCE_VOLUME_NAME_COLUMN_NAME,
     SEGMENTATION_NAME_COLUMN_NAME,
     TERMINOLOGY_COLUMN_NAME,
     MODULE_NAME_COLUMN_NAME,
@@ -230,7 +230,7 @@ class UserStatisticsLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
   defaultSerializedParameters = [
     OPERATION_COLUMN_NAME,
     SEGMENT_NAME_COLUMN_NAME,
-    MASTER_VOLUME_NAME_COLUMN_NAME,
+    SOURCE_VOLUME_NAME_COLUMN_NAME,
     SEGMENTATION_NAME_COLUMN_NAME,
     TERMINOLOGY_COLUMN_NAME,
     MODULE_NAME_COLUMN_NAME,
@@ -717,10 +717,10 @@ class UserStatisticsLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
       userInfo = slicer.app.applicationLogic().GetUserInformation()
       value = userInfo.GetName()
 
-    elif name == self.MASTER_VOLUME_NAME_COLUMN_NAME:
-      masterVolume = self.getMasterVolumeNode()
-      if masterVolume:
-        value = masterVolume.GetName()
+    elif name == self.SOURCE_VOLUME_NAME_COLUMN_NAME:
+      sourceVolume = self.getSourceVolumeNode()
+      if sourceVolume:
+        value = sourceVolume.GetName()
 
     elif name == self.START_TIME_COLUMN_NAME:
       value = tableNode.GetCellText(self.getActiveRow(), tableNode.GetColumnIndex(name))
@@ -772,10 +772,10 @@ class UserStatisticsLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
       return None
     return self.editorNode.GetSegmentationNode()
 
-  def getMasterVolumeNode(self):
+  def getSourceVolumeNode(self):
     if self.editorNode is None:
       return None
-    return self.editorNode.GetMasterVolumeNode()
+    return self.editorNode.GetSourceVolumeNode()
 
   def getSelectedSegment(self):
     if self.editorNode is None:
@@ -799,7 +799,7 @@ class UserStatisticsTest(ScriptedLoadableModuleTest):
   """
   This is the test case for your scripted module.
   Uses ScriptedLoadableModuleTest base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def setUp(self):

--- a/VolumeRenderingSpecialEffects/VolumeRenderingSpecialEffects.py
+++ b/VolumeRenderingSpecialEffects/VolumeRenderingSpecialEffects.py
@@ -11,7 +11,7 @@ from slicer.util import VTKObservationMixin
 
 class VolumeRenderingSpecialEffects(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):
@@ -34,7 +34,7 @@ and Steve Pieper, Isomics, Inc. and was partially funded by NIH grant 3P41RR0132
 
 class VolumeRenderingSpecialEffectsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   """Uses ScriptedLoadableModuleWidget base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent=None):
@@ -213,7 +213,7 @@ class VolumeRenderingSpecialEffectsLogic(ScriptedLoadableModuleLogic, VTKObserva
   this class and make use of the functionality without
   requiring an instance of the Widget.
   Uses ScriptedLoadableModuleLogic base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self):
@@ -353,7 +353,7 @@ class VolumeRenderingSpecialEffectsTest(ScriptedLoadableModuleTest):
   """
   This is the test case for your scripted module.
   Uses ScriptedLoadableModuleTest base class, available at:
-  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def setUp(self):


### PR DESCRIPTION
See https://tools.ietf.org/id/draft-knodel-terminology-09.html#name-master-slave , following Slicer updates to move towards more inclusive language beginning with the Slicer 5.2 release.

There's still a few instances of "master" around in this repo:
- References to resources in this repo, such as https://github.com/PerkLab/SlicerSandbox/blob/247943ef982f1840ba4b0bfac692a43d58be6457/ImportOsirixROI/ImportOsirixROI.py#L429 It would be nice to move to a "main" branch from the current "master" branch to address this
- `setMasterRepresentationName`, which seems to not yet have been deprecated (https://github.com/Slicer/Slicer/blob/a328293e72649c45d7f833c6a969b45861a6b267/Libs/vtkSegmentationCore/vtkSegmentation.h#L479), I can issue something to Slicer for this soon