### PR TITLE
Fix LineProfile bug where wrong curve length was used

### DIFF
--- a/LineProfile/LineProfile.py
+++ b/LineProfile/LineProfile.py
@@ -463,7 +463,8 @@ class LineProfileLogic(ScriptedLoadableModuleLogic):
           curvePoints_IJK.SetPoint(endPointIndex, lineEndPoint_IJK)
 
     sampledCurvePoints_IJK = vtk.vtkPoints()
-    samplingDistance = curveLengthMm / lineResolution
+    curveLengthIJK = slicer.vtkMRMLMarkupsCurveNode.GetCurveLength(curvePoints_IJK, closedCurve)
+    samplingDistance = curveLengthIJK / lineResolution
     slicer.vtkMRMLMarkupsCurveNode.ResamplePoints(curvePoints_IJK, sampledCurvePoints_IJK, samplingDistance, closedCurve)
 
     sampledCurvePoly_IJK = vtk.vtkPolyData()

--- a/LineProfile/LineProfile.py
+++ b/LineProfile/LineProfile.py
@@ -20,7 +20,13 @@ class LineProfile(ScriptedLoadableModule):
     self.parent.dependencies = []
     parent.contributors = ["Andras Lasso (PerkLab)"]
     self.parent.helpText = """
-This module computes intensity profile of a volume along a line line.
+This module computes the intensity profile of a volume along a markups line or curve. 
+Be aware that, due to the behavior of the underlying vtkProbeFilter, erroneous results
+are sometimes returned for values within 1/2 voxel of image boundaries. Probed points
+further than 1/2 voxel outside of the image boundary always return a value of 0. Probed
+points within the image volume are linearly interpolated among adjacent voxel centers
+and then returned with the same data type as the probed image (e.g. rounded to integers
+if the image has integer data type).
 """
     self.parent.helpText += self.getDefaultModuleDocumentationLink()
     self.parent.acknowledgementText = """
@@ -391,7 +397,7 @@ class LineProfileLogic(ScriptedLoadableModuleLogic):
 
   def getArrayFromTable(self, outputTable, arrayName):
     if outputTable is None:
-      return None;
+      return None
     distanceArray = outputTable.GetTable().GetColumnByName(arrayName)
     if distanceArray:
       return distanceArray
@@ -410,6 +416,9 @@ class LineProfileLogic(ScriptedLoadableModuleLogic):
     curvePoints_RAS = inputCurve.GetCurvePointsWorld()
     closedCurve = inputCurve.IsA('vtkMRMLClosedCurveNode')
     curveLengthMm = slicer.vtkMRMLMarkupsCurveNode.GetCurveLength(curvePoints_RAS, closedCurve)
+    samplingDistance = curveLengthMm/lineResolution
+    sampledCurvePoints_RAS = vtk.vtkPoints()
+    slicer.vtkMRMLMarkupsCurveNode.ResamplePoints(curvePoints_RAS, sampledCurvePoints_RAS, samplingDistance, closedCurve)
 
     # Need to get the start/end point of the line in the IJK coordinate system
     # as VTK filters cannot take into account direction cosines
@@ -423,53 +432,48 @@ class LineProfileLogic(ScriptedLoadableModuleLogic):
     rasToIJKTransform.Concatenate(inputVolumeToIJK)
     rasToIJKTransform.Concatenate(rasToInputVolumeTransform)
 
-    curvePoly_RAS = vtk.vtkPolyData()
-    curvePoly_RAS.SetPoints(curvePoints_RAS)
+    sampledCurvePoly_RAS = vtk.vtkPolyData()
+    sampledCurvePoly_RAS.SetPoints(sampledCurvePoints_RAS)
 
     transformRasToIjk = vtk.vtkTransformPolyDataFilter()
-    transformRasToIjk.SetInputData(curvePoly_RAS)
+    transformRasToIjk.SetInputData(sampledCurvePoly_RAS)
     transformRasToIjk.SetTransform(rasToIJKTransform)
     transformRasToIjk.Update()
-    curvePoly_IJK = transformRasToIjk.GetOutput()
-    curvePoints_IJK = curvePoly_IJK.GetPoints()
+    sampledCurvePoly_IJK = transformRasToIjk.GetOutput()
+    sampledCurvePoints_IJK = sampledCurvePoly_IJK.GetPoints()
 
-    if curvePoints_IJK.GetNumberOfPoints() < 2:
+    if sampledCurvePoints_IJK.GetNumberOfPoints() < 2:
       # We checked before that there are at least two control points, so it should not happen
       raise ValueError()
 
     startPointIndex = 0
-    endPointIndex = curvePoints_IJK.GetNumberOfPoints() - 1
-    lineStartPoint_IJK = curvePoints_IJK.GetPoint(startPointIndex)
-    lineEndPoint_IJK = curvePoints_IJK.GetPoint(endPointIndex)
+    endPointIndex = sampledCurvePoints_IJK.GetNumberOfPoints() - 1
+    lineStartPoint_IJK = sampledCurvePoints_IJK.GetPoint(startPointIndex)
+    lineEndPoint_IJK = sampledCurvePoints_IJK.GetPoint(endPointIndex)
 
     # Special case: single-slice volume
     # vtkProbeFilter treats vtkImageData as a general data set and it considers its bounds to end
     # in the middle of edge voxels. This makes single-slice volumes to have zero thickness, which
     # can be easily missed by a line that that is drawn on the plane (e.g., they happen to be
-    # extremely on the same side of the plane, very slightly off, due to runding errors).
-    # We move the start/end points very close to the plane and force them to be on opposite sides of the plane.
+    # just barely on the same side of the plane, very slightly off, due to rounding errors).
+    # We move the start/end points very close to the plane and force them to be on opposite 
+    # sides of the plane.
     dims = inputVolume.GetImageData().GetDimensions()
     for axisIndex in range(3):
       if dims[axisIndex] == 1:
+        # This is a 2D image (only one pixel layer thick)
         if abs(lineStartPoint_IJK[axisIndex]) < 0.5 and abs(lineEndPoint_IJK[axisIndex]) < 0.5:
           # both points are inside the volume plane
-          # keep their distance the same (to keep the overall length of the line he same)
-          # but make sure the points are on the opposite side of the plane (to ensure probe filter
-          # considers the line crossing the image plane)
+          # keep their relative distance the same (or boost to 1e-6 if very small) 
+          # but make sure the points are on the opposite side of the 
+          # plane (to ensure probe filter considers the line crossing the image plane)
           pointDistance = max(abs(lineStartPoint_IJK[axisIndex]-lineEndPoint_IJK[axisIndex]), 1e-6)
           lineStartPoint_IJK[axisIndex] = -0.5 * pointDistance
           lineEndPoint_IJK[axisIndex] = 0.5 * pointDistance
-          curvePoints_IJK.SetPoint(startPointIndex, lineStartPoint_IJK)
-          curvePoints_IJK.SetPoint(endPointIndex, lineEndPoint_IJK)
+          sampledCurvePoints_IJK.SetPoint(startPointIndex, lineStartPoint_IJK)
+          sampledCurvePoints_IJK.SetPoint(endPointIndex, lineEndPoint_IJK)
 
-    sampledCurvePoints_IJK = vtk.vtkPoints()
-    curveLengthIJK = slicer.vtkMRMLMarkupsCurveNode.GetCurveLength(curvePoints_IJK, closedCurve)
-    samplingDistance = curveLengthIJK / lineResolution
-    slicer.vtkMRMLMarkupsCurveNode.ResamplePoints(curvePoints_IJK, sampledCurvePoints_IJK, samplingDistance, closedCurve)
-
-    sampledCurvePoly_IJK = vtk.vtkPolyData()
-    sampledCurvePoly_IJK.SetPoints(sampledCurvePoints_IJK)
-
+    # Set up probe filter
     probeFilter=vtk.vtkProbeFilter()
     probeFilter.SetInputData(sampledCurvePoly_IJK)
     probeFilter.SetSourceData(inputVolume.GetImageData())


### PR DESCRIPTION
LineProfile used the curve length in mm to calculate the sampling distance between resampled points used to probe to get the profile values, however, the curve which is resampled has been converted to use IJK coordinates instead.  Therefore we need to use the curve length in IJK space which calculating the sampling distance, otherwise, we will get the wrong number of sampling points. I discovered this when the probe filter returned 378 sampled points for an input lineResolution of 100 on the image I was working with. The only change in this PR is to calculate the curve length in IJK coordinates and use that instead when calculating the sampling distance. 