### PR TITLE
ENH: configure outputModel selector of CombineModels

### DIFF
--- a/CombineModels/Resources/UI/CombineModels.ui
+++ b/CombineModels/Resources/UI/CombineModels.ui
@@ -180,13 +180,13 @@
          <bool>true</bool>
         </property>
         <property name="addEnabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="removeEnabled">
          <bool>true</bool>
         </property>
         <property name="editEnabled">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <property name="renameEnabled">
          <bool>true</bool>


### PR DESCRIPTION
MRML selector node was changed to allow renaming the node, and hide the edit node option