### PR TITLE
ENH: Support movement of combine model inputs

### DIFF
--- a/CombineModels/Logic/Contact.cxx
+++ b/CombineModels/Logic/Contact.cxx
@@ -165,18 +165,53 @@ Contact::Contact (vtkPolyData *newPdA, vtkPolyData *newPdB) : newPdA(newPdA), ne
 
     GetNonManifoldEdges(newPdA, edgesA);
     GetNonManifoldEdges(newPdB, edgesB);
-}
 
-vtkSmartPointer<vtkPolyData> Contact::GetLines () {
-    auto treeA = vtkSmartPointer<vtkOBBTree>::New();
+    treeA = vtkSmartPointer<vtkOBBTree>::New();
     treeA->SetDataSet(newPdA);
     treeA->BuildLocator();
 
-    auto treeB = vtkSmartPointer<vtkOBBTree>::New();
+    treeB = vtkSmartPointer<vtkOBBTree>::New();
     treeB->SetDataSet(newPdB);
     treeB->BuildLocator();
+}
 
-    treeA->IntersectWithOBBTree(treeB, nullptr, InterNodes, this);
+vtkSmartPointer<vtkPolyData> Contact::GetLines (vtkPolyData *pdA, vtkLinearTransform *transA, vtkPolyData *pdB, vtkLinearTransform *transB) {
+
+    auto matrix = vtkSmartPointer<vtkMatrix4x4>::New();
+
+    if (pdA != nullptr) {
+        newPdA = pdA;
+    }
+
+    if (pdB != nullptr) {
+        newPdB = pdB;
+    }
+
+    auto matrixA = vtkSmartPointer<vtkMatrix4x4>::New();
+
+    if (transA != nullptr) {
+        matrixA = transA->GetMatrix();
+    }
+
+    auto matrixB = vtkSmartPointer<vtkMatrix4x4>::New();
+
+    if (transB != nullptr) {
+        matrixB = transB->GetMatrix();
+    }
+
+    auto tmpMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+
+    vtkMatrix4x4::Invert(matrixA, tmpMatrix);
+    vtkMatrix4x4::Multiply4x4(tmpMatrix, matrixB, matrix);
+
+    sourcesA->Reset();
+    sourcesB->Reset();
+    contA->Reset();
+    contB->Reset();
+
+    lines->Reset();
+
+    treeA->IntersectWithOBBTree(treeB, matrix, InterNodes, this);
 
     IntersectReplacements();
 
@@ -573,13 +608,8 @@ void Contact::InterPolys (vtkIdType idA, vtkIdType idB) {
         return;
     }
 
-    double ptA[3], ptB[3];
-
-    newPdA->GetPoint(ptsA[0], ptA);
-    newPdB->GetPoint(ptsB[0], ptB);
-
-    double dA = vtkMath::Dot(nA, ptA);
-    double dB = vtkMath::Dot(nB, ptB);
+    double dA = polyA[0].x*nA[0]+polyA[0].y*nA[1]+polyA[0].z*nA[2];
+    double dB = polyB[0].x*nB[0]+polyB[0].y*nB[1]+polyB[0].z*nB[2];
 
     vtkMath::Cross(nA, nB, r);
     vtkMath::Normalize(r);
@@ -998,5 +1028,3 @@ void Contact::IntersectReplacements () {
     newPdB->GetCellData()->RemoveArray("OldCellIds");
 
 }
-
-// vtkStandardNewMacro(Contact);

--- a/CombineModels/Logic/Contact.h
+++ b/CombineModels/Logic/Contact.h
@@ -23,6 +23,7 @@ limitations under the License.
 
 #include <vtkOBBTree.h>
 #include <vtkMatrix4x4.h>
+#include <vtkLinearTransform.h>
 #include <vtkObject.h>
 #include <vtkObjectFactory.h>
 
@@ -127,7 +128,9 @@ public:
 
     NonManifoldEdgesType edgesA, edgesB;
 
-    vtkSmartPointer<vtkPolyData> GetLines ();
+    vtkSmartPointer<vtkOBBTree> treeA, treeB;
+
+    vtkSmartPointer<vtkPolyData> GetLines (vtkPolyData *pdA = nullptr, vtkLinearTransform *transA = nullptr, vtkPolyData *pdB = nullptr, vtkLinearTransform *transB = nullptr);
 
     void GetNonManifoldEdges (vtkPolyData *pd, NonManifoldEdgesType &edges);
 

--- a/CombineModels/Logic/Optimize.cxx
+++ b/CombineModels/Logic/Optimize.cxx
@@ -85,6 +85,8 @@ void PreventEqualCaptPoints::Find (vtkPolyData *pd, vtkPolyData *other, [[maybe_
     tree->BuildLocator();
 
     auto pts = vtkSmartPointer<vtkPoints>::New();
+    pts->SetDataTypeToDouble();
+
     auto cells = vtkSmartPointer<vtkIdList>::New();
 
     double pA[3], pB[3];
@@ -98,6 +100,7 @@ void PreventEqualCaptPoints::Find (vtkPolyData *pd, vtkPolyData *other, [[maybe_
     pdVerts->Allocate(1);
 
     auto ptsVerts = vtkSmartPointer<vtkPoints>::New();
+    ptsVerts->SetDataTypeToDouble();
 #endif
 
     std::map<vtkIdType, std::vector<SnapPoint>> pointSnaps;
@@ -291,7 +294,7 @@ void PreventEqualCaptPoints::Find (vtkPolyData *pd, vtkPolyData *other, [[maybe_
             const auto &snapA = snaps[0];
             const auto &snapB = snaps[1];
 
-            if (Point3d::GetDist(snapA.inter, snapB.inter) > 1e-10) {
+            {
                 Pair edge(snapA.edge);
 
                 if (edge.f > edge.g) {

--- a/CombineModels/Logic/Utilities.cxx
+++ b/CombineModels/Logic/Utilities.cxx
@@ -133,7 +133,7 @@ void Transform (const double *in, double *out, const Base &base) {
     out[1] = y;
 }
 
-void BackTransform (const double *in, double *out, const Base &base) {
+/*void BackTransform (const double *in, double *out, const Base &base) {
     double x = in[0]*base.ei[0]+in[1]*base.ej[0]+base.d*base.n[0],
         y = in[0]*base.ei[1]+in[1]*base.ej[1]+base.d*base.n[1],
         z = in[0]*base.ei[2]+in[1]*base.ej[2]+base.d*base.n[2];
@@ -141,7 +141,7 @@ void BackTransform (const double *in, double *out, const Base &base) {
     out[0] = x;
     out[1] = y;
     out[2] = z;
-}
+}*/
 
 double ComputeNormal (const Poly &poly, double *n) {
     n[0] = 0; n[1] = 0; n[2] = 0;
@@ -198,6 +198,7 @@ bool PointInPoly (const Poly &poly, const Point3d &p) {
 #ifdef DEBUG
 void WritePolys (const char *name, const PolysType &polys) {
     auto pts = vtkSmartPointer<vtkPoints>::New();
+    pts->SetDataTypeToDouble();
 
     auto pd = vtkSmartPointer<vtkPolyData>::New();
     pd->SetPoints(pts);

--- a/CombineModels/Logic/Utilities.h
+++ b/CombineModels/Logic/Utilities.h
@@ -90,6 +90,8 @@ public:
 
         return dx*dx+dy*dy+dz*dz;
     }
+
+
 };
 
 typedef std::vector<vtkIdType> IdsType;

--- a/CombineModels/Logic/Utilities.h
+++ b/CombineModels/Logic/Utilities.h
@@ -48,10 +48,10 @@ void WriteVTK (const char *name, vtkPolyData *pd);
 class Point3d {
 public:
     const double x, y, z;
-    vtkIdType id;
+    vtkIdType id, otherId;
 
     Point3d () = delete;
-    Point3d (const double x, const double y, const double z, vtkIdType id = NOTSET) : x(x), y(y), z(z), id(id) {}
+    Point3d (const double x, const double y, const double z, vtkIdType id = NOTSET, vtkIdType otherId = NOTSET) : x(x), y(y), z(z), id(id), otherId(otherId) {}
     bool operator< (const Point3d &other) const {
         const long x1 = std::lround(x*1e5),
             y1 = std::lround(y*1e5),
@@ -70,7 +70,8 @@ public:
         out << "Point3d(x=" << p.x
             << ", y=" << p.y
             << ", z=" << p.z
-            << ", id=" << p.id << ")";
+            << ", id=" << p.id
+            << ", otherId=" << p.otherId << ")";
         return out;
     }
 
@@ -125,7 +126,7 @@ public:
 };
 
 void Transform (const double *in, double *out, const Base &base);
-void BackTransform (const double *in, double *out, const Base &base);
+// void BackTransform (const double *in, double *out, const Base &base);
 
 class Base2 {
 public:

--- a/CombineModels/Logic/vtkPolyDataBooleanFilter.cxx
+++ b/CombineModels/Logic/vtkPolyDataBooleanFilter.cxx
@@ -144,10 +144,10 @@ int vtkPolyDataBooleanFilter::RequestData(vtkInformation *request, vtkInformatio
                 cleanA = Clean(pdA);
                 cleanB = Clean(pdB);
 
-    #ifdef DEBUG
-                WriteVTK("modPdA.vtk", cleanA);
-                WriteVTK("modPdB.vtk", cleanB);
-    #endif
+#ifdef DEBUG
+            WriteVTK("modPdA.vtk", cleanA);
+            WriteVTK("modPdB.vtk", cleanB);
+#endif
 
                 try {
                     PreventEqualCaptPoints(cleanA, cleanB).Run();
@@ -3097,12 +3097,12 @@ void vtkPolyDataBooleanFilter::SetMatrix (int i, vtkMatrix4x4 *matrix) {
         return;
     }
 
-    if (transforms[i]) {
+    if (transforms[i] != nullptr) {
         transforms[i]->Delete();
         transforms[i] = nullptr;
     }
 
-    if (matrices[i]) {
+    if (matrices[i] != nullptr) {
         matrices[i]->Delete();
         matrices[i] = nullptr;
     }

--- a/CombineModels/Logic/vtkPolyDataBooleanFilter.cxx
+++ b/CombineModels/Logic/vtkPolyDataBooleanFilter.cxx
@@ -47,6 +47,7 @@ limitations under the License.
 #include <vtkCellArrayIterator.h>
 #include <vtkKdTree.h>
 #include <vtkCellIterator.h>
+#include <vtkTransformPolyDataFilter.h>
 
 #include "vtkPolyDataBooleanFilter.h"
 
@@ -78,10 +79,33 @@ vtkPolyDataBooleanFilter::vtkPolyDataBooleanFilter () {
 
     OperMode = OPER_UNION;
 
+    matrices[0] = nullptr;
+    matrices[1] = nullptr;
+
+    transforms[0] = nullptr;
+    transforms[1] = nullptr;
+
+    timeMatrixA = 0;
+    timeMatrixB = 0;
+
 }
 
 vtkPolyDataBooleanFilter::~vtkPolyDataBooleanFilter () {
-    // nix mehr
+    if (matrices[0] != nullptr) {
+        matrices[0]->Delete();
+    }
+
+    if (matrices[1] != nullptr) {
+        matrices[1]->Delete();
+    }
+
+    if (transforms[0] != nullptr) {
+        transforms[0]->Delete();
+    }
+
+    if (transforms[1] != nullptr) {
+        transforms[1]->Delete();
+    }
 }
 
 int vtkPolyDataBooleanFilter::RequestData(vtkInformation *request, vtkInformationVector **inputVector, vtkInformationVector *outputVector) {
@@ -106,36 +130,67 @@ int vtkPolyDataBooleanFilter::RequestData(vtkInformation *request, vtkInformatio
         std::vector<clock::duration> times;
         clock::time_point start;
 
-        if (pdA->GetMTime() > timePdA || pdB->GetMTime() > timePdB) {
-            // CellData sichern
+        vtkMTimeType timeA = pdA->GetMTime();
+        vtkMTimeType timeB = pdB->GetMTime();
 
-            cellDataA->DeepCopy(pdA->GetCellData());
-            cellDataB->DeepCopy(pdB->GetCellData());
+        if (timeA > timePdA || timeB > timePdB || (matrices[0] != nullptr && matrices[0]->GetMTime() > timeMatrixA) || (matrices[1] != nullptr && matrices[1]->GetMTime() > timeMatrixB)) {
 
-            modPdA = Clean(pdA);
-            modPdB = Clean(pdB);
+            if (contact == nullptr || timeA > timePdA || timeB > timePdB) {
+                // CellData sichern
 
-            modPdA->EditableOn();
-            modPdB->EditableOn();
+                cellDataA->DeepCopy(pdA->GetCellData());
+                cellDataB->DeepCopy(pdB->GetCellData());
 
-#ifdef DEBUG
-            WriteVTK("modPdA.vtk", modPdA);
-            WriteVTK("modPdB.vtk", modPdB);
-#endif
+                cleanA = Clean(pdA);
+                cleanB = Clean(pdB);
 
-            try {
-                PreventEqualCaptPoints(modPdA, modPdB).Run();
-            } catch (const std::runtime_error &e) {
-                vtkErrorMacro("Cannot prevent equal capture points.");
-                return 1;
+    #ifdef DEBUG
+                WriteVTK("modPdA.vtk", cleanA);
+                WriteVTK("modPdB.vtk", cleanB);
+    #endif
+
+                try {
+                    PreventEqualCaptPoints(cleanA, cleanB).Run();
+                } catch (const std::runtime_error &e) {
+                    vtkErrorMacro("Cannot prevent equal capture points.");
+                    return 1;
+                }
+
+                contact = std::make_shared<Contact>(cleanA, cleanB);
             }
 
             start = clock::now();
 
-            Contact contact(modPdA, modPdB);
+            modPdA = vtkSmartPointer<vtkPolyData>::New();
+            modPdB = vtkSmartPointer<vtkPolyData>::New();
+
+            if (transforms[0] != nullptr) {
+                auto tfA = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+                tfA->SetInputData(cleanA);
+                tfA->SetTransform(transforms[0]);
+                tfA->Update();
+
+                modPdA->DeepCopy(tfA->GetOutput());
+            } else {
+                modPdA->DeepCopy(cleanA);
+            }
+
+            if (transforms[1] != nullptr) {
+                auto tfB = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+                tfB->SetInputData(cleanB);
+                tfB->SetTransform(transforms[1]);
+                tfB->Update();
+
+                modPdB->DeepCopy(tfB->GetOutput());
+            } else {
+                modPdB->DeepCopy(cleanB);
+            }
+
+            modPdA->EditableOn();
+            modPdB->EditableOn();
 
             try {
-                contLines = contact.GetLines();
+                contLines = contact->GetLines(modPdA, transforms[0], modPdB, transforms[1]);
             } catch (const std::runtime_error &e) {
                 std::stringstream ss;
                 ss << std::quoted(e.what());
@@ -296,6 +351,14 @@ int vtkPolyDataBooleanFilter::RequestData(vtkInformation *request, vtkInformatio
 
             timePdA = pdA->GetMTime();
             timePdB = pdB->GetMTime();
+
+            if (matrices[0] != nullptr) {
+                timeMatrixA = matrices[0]->GetMTime();
+            }
+
+            if (matrices[1] != nullptr) {
+                timeMatrixB = matrices[1]->GetMTime();
+            }
 
         }
 
@@ -3023,4 +3086,62 @@ bool vtkPolyDataBooleanFilter::CombineRegions () {
 
     return false;
 
+}
+
+void vtkPolyDataBooleanFilter::SetMatrix (int i, vtkMatrix4x4 *matrix) {
+    if (i != 0 && i != 1) {
+        return;
+    }
+
+    if (matrices[i] == matrix) {
+        return;
+    }
+
+    if (transforms[i]) {
+        transforms[i]->Delete();
+        transforms[i] = nullptr;
+    }
+
+    if (matrices[i]) {
+        matrices[i]->Delete();
+        matrices[i] = nullptr;
+    }
+
+    if (matrix != nullptr) {
+        matrices[i] = matrix;
+        matrix->Register(this);
+
+        auto transform = vtkMatrixToLinearTransform::New();
+
+        transform->Register(this);
+        transform->Delete();
+
+        transform->SetInput(matrix);
+
+        transforms[i] = transform;
+    }
+
+    Modified();
+}
+
+vtkMatrix4x4* vtkPolyDataBooleanFilter::GetMatrix (int i) {
+    if (i != 0 && i != 1) {
+        return nullptr;
+    }
+
+    return matrices[i];
+}
+
+vtkMTimeType vtkPolyDataBooleanFilter::GetMTime () {
+    std::vector<vtkMTimeType> times = { MTime.GetMTime() };
+
+    if (matrices[0] != nullptr) {
+        times.push_back(matrices[0]->GetMTime());
+    }
+
+    if (matrices[1] != nullptr) {
+        times.push_back(matrices[1]->GetMTime());
+    }
+
+    return *std::max_element(times.begin(), times.end());
 }

--- a/CombineModels/Logic/vtkPolyDataBooleanFilter.cxx
+++ b/CombineModels/Logic/vtkPolyDataBooleanFilter.cxx
@@ -590,8 +590,6 @@ bool vtkPolyDataBooleanFilter::GetPolyStrips (vtkPolyData *pd, vtkIdTypeArray *c
     // sucht nach gleichen captPts
 
     {
-        // std::map<Point3d, std::map<vtkIdType, std::vector<std::reference_wrapper<StripPt>>>> collapsed;
-
         std::map<Point3d, std::set<vtkIdType>> collapsed;
 
         PolyStripsType::iterator itr;
@@ -606,24 +604,16 @@ bool vtkPolyDataBooleanFilter::GetPolyStrips (vtkPolyData *pd, vtkIdTypeArray *c
                 StripPt &sp = itr2->second;
 
                 if (sp.capt & Capt::Boundary) {
-                    // collapsed[{sp.cutPt[0], sp.cutPt[1], sp.cutPt[2]}][sp.ind].push_back(sp);
+                    Point3d p(sp.cutPt[0], sp.cutPt[1], sp.cutPt[2]);
 
-                    auto inds = collapsed[{sp.cutPt[0], sp.cutPt[1], sp.cutPt[2]}];
+                    collapsed[p].emplace(sp.ind);
 
-                    inds.emplace(sp.ind);
-
-                    if (inds.size() > 1) {
+                    if (collapsed[p].size() == 2) {
                         return true;
                     }
                 }
             }
         }
-
-        // for (auto &[pt, map] : collapsed) {
-        //     if (map.size() > 1) {
-        //         return true;
-        //     }
-        // }
     }
 
     for (itr = polyLines.begin(); itr != polyLines.end(); ++itr) {
@@ -729,6 +719,7 @@ bool vtkPolyDataBooleanFilter::GetPolyStrips (vtkPolyData *pd, vtkIdTypeArray *c
             const Base &base = pStrips.base;
 
             auto treePts = vtkSmartPointer<vtkPoints>::New();
+            treePts->SetDataTypeToDouble();
 
             auto treePd = vtkSmartPointer<vtkPolyData>::New();
             treePd->Allocate(1);
@@ -1952,8 +1943,6 @@ void vtkPolyDataBooleanFilter::ResolveOverlaps (vtkPolyData *pd, PolyStripsType 
             auto edgeA = pairA.second.get().edge;
             auto edgeB = pairB.second.get().edge;
 
-            assert(edgeA[1] == edgeB[0]);
-
             if (edgeA[1] == edgeB[0] && edgeA[0] != edgeB[1]) {
 
 #ifdef DEBUG
@@ -2827,8 +2816,6 @@ bool vtkPolyDataBooleanFilter::CombineRegions () {
 
         } else {
             _failed.push_back(i);
-
-            // return true;
         }
 
     }

--- a/CombineModels/Logic/vtkPolyDataBooleanFilter.h
+++ b/CombineModels/Logic/vtkPolyDataBooleanFilter.h
@@ -30,6 +30,10 @@ limitations under the License.
 #include <vtkPolyDataAlgorithm.h>
 #include <vtkKdTree.h>
 #include <vtkModifiedBSPTree.h>
+#include <vtkMatrixToLinearTransform.h>
+#include <vtkMatrix4x4.h>
+
+#include "Contact.h"
 
 #include "Utilities.h"
 
@@ -172,7 +176,7 @@ class VTK_SLICER_COMBINEMODELS_MODULE_LOGIC_EXPORT vtkPolyDataBooleanFilter : pu
 
     vtkIdTypeArray *contsA, *contsB;
 
-    unsigned long timePdA, timePdB;
+    vtkMTimeType timePdA, timePdB;
 
     PolyStripsType polyStripsA, polyStripsB;
 
@@ -192,6 +196,15 @@ class VTK_SLICER_COMBINEMODELS_MODULE_LOGIC_EXPORT vtkPolyDataBooleanFilter : pu
 
     int OperMode;
 
+    vtkMatrix4x4 *matrices[2];
+    vtkLinearTransform *transforms[2];
+
+    vtkSmartPointer<vtkPolyData> cleanA, cleanB;
+
+    std::shared_ptr<Contact> contact;
+
+    vtkMTimeType timeMatrixA, timeMatrixB;
+
 public:
     vtkTypeMacro(vtkPolyDataBooleanFilter, vtkPolyDataAlgorithm);
     static vtkPolyDataBooleanFilter* New ();
@@ -204,6 +217,11 @@ public:
     void SetOperModeToIntersection () { OperMode = OPER_INTERSECTION; Modified(); }
     void SetOperModeToDifference () { OperMode = OPER_DIFFERENCE; Modified(); }
     void SetOperModeToDifference2 () { OperMode = OPER_DIFFERENCE2; Modified(); }
+
+    void SetMatrix (int i, vtkMatrix4x4 *matrix);
+    vtkMatrix4x4* GetMatrix (int i);
+
+    vtkMTimeType GetMTime () override;
 
 protected:
     vtkPolyDataBooleanFilter ();


### PR DESCRIPTION
 _Originally posted by @zippy84 in [#74](https://github.com/zippy84/vtkbool/issues/74#issuecomment-3114430923)_:
> It takes only half as long as without _SetMatrix_.

As stated by Ronald, secondary executions of this boolean filter, only changing the input matrices, should execute twice as fast as the first one. This new feature is currently only reachable through code and it is not exposed on the UI yet as I did not know how to present it to the user in a convenient way.

Here is a [test](https://github.com/zippy84/vtkbool/issues/74#issuecomment-3148767393) that shows how it works.

Note: This PR also updates vtkbool version to latest available